### PR TITLE
Aligned emojis in group-status command

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -429,6 +429,7 @@ disable=raw-checker-failed,
         E1121, # Ignoring too many position arguemnts error until we refactor
         R0801, # This is a really dumb linter rule that suppresses using abstration
         R0903, # Another dumb error related to "too few public methods"
+        R0914, # Too many local variables. A reasonable error but we need to refactor to address
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where

--- a/src/utils/commands/command_util.py
+++ b/src/utils/commands/command_util.py
@@ -225,13 +225,15 @@ Supported commands:
                 result += f"**Group completion:** {group_percentage}%"
         if challenge:
             result += "\n\n"
+            max_name_width = max(list(len(u["leetcode_id"]) for u in users))
             for user in users:
-                stars = Emojis.star * user_scores[user["leetcode_id"]]
-                # NOTICE: In the future all database methods should return a well-defined
-                #         object. That avoids having to do things like the following and
-                #         allows for direct access via dot-operator
-                LEETCODE_STR = "leetcode_id"
-                result += f"\t{user[LEETCODE_STR]}: {stars}\n"
+                if user_scores[user["leetcode_id"]]:
+                    stars = Emojis.star * user_scores[user["leetcode_id"]]
+                    # NOTICE: In the future all database methods should return a well-defined
+                    #         object. That avoids having to do things like the following and
+                    #         allows for direct access via dot-operator
+                    LEETCODE_STR = "leetcode_id"
+                    result += f"`  {user[LEETCODE_STR].rjust(max_name_width)}` {stars}\n"
         return result
 
     def run(self) -> None:


### PR DESCRIPTION
- Needed to disable pylint rules for too many variables. Considering as tech debt.